### PR TITLE
fix: preExecTransaction event

### DIFF
--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -164,10 +164,6 @@ class NotificationService extends Events {
   rejectApproval = async (err?: string, stay = false, isInternal = false) => {
     const approval = this.currentApproval;
 
-    if (this.approvals.length <= 1) {
-      await this.clear(stay); // TODO: FIXME
-    }
-
     if (isInternal) {
       approval?.reject && approval?.reject(ethErrors.rpc.internal(err));
     } else {


### PR DESCRIPTION
插件端正常，原因是因为 electron 与浏览器  `winMgr.event.on('windowRemoved', xxx)`时机不一致。所以同样是clear，electron 先清掉  `transactionHistoryService.removeAllSigningTx();` 导致 reject 埋点获取数据的时候获取不到了。