### PR TITLE
test: verify pull request workflow trigger

### DIFF
--- a/.github/actions-pr-trigger-test.md
+++ b/.github/actions-pr-trigger-test.md
@@ -1,0 +1,3 @@
+# Actions workflow trigger probe
+
+This draft PR contains no executable changes. It only verifies whether the upstream pull_request workflow starts automatically or requires maintainer approval.


### PR DESCRIPTION
Security validation only. This PR adds a non-executable documentation file to verify whether the public-repository `pull_request` workflow starts automatically on the shared self-hosted runner or waits for maintainer approval. No build scripts or application code are changed.